### PR TITLE
Handle corrupted `config.json` in non-interactive runs

### DIFF
--- a/changelog.d/20251219_150621_sderev_noninteractive_config_fallback.md
+++ b/changelog.d/20251219_150621_sderev_noninteractive_config_fallback.md
@@ -1,0 +1,3 @@
+Fixed
+-----
+* Avoided blocking non-interactive runs when `config.json` is corrupted by backing it up and restoring defaults (PERSO-257).


### PR DESCRIPTION
* Detect non-interactive stdin and restore defaults without prompting
* Backup corrupted config to `config.json.corrupted*`
* Add tests for non-interactive recovery path
* Add scriv fragment

Co-authored-by: AI <ai@sderev.com>
