### PR TITLE
Remove `screenshot_`/`animated_` prefixes from generated filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Note that you can _drag and drop_ a file into the Windows Terminal to automatica
 Upon success, the command will output the new path of the image in Markdown format:
 
 ```bash
-![magic.gif](/assets/images/animated_magic.gif)
+![{uuid}.gif](/assets/images/{uuid}.gif)
 ```
 
 ### File Copy Behavior

--- a/changelog.d/20251222_220907_sderev_remove_filename_prefixes.md
+++ b/changelog.d/20251222_220907_sderev_remove_filename_prefixes.md
@@ -1,0 +1,3 @@
+Security
+--------
+* Removed semantic prefixes from generated screenshot filenames to improve anonymization.

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -16,7 +16,7 @@ def test_generate_screenshot_name_uses_uuid(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     image_path = Path("/tmp/source/screenshot.png")
-    assert cli.generate_screenshot_name(image_path) == f"screenshot_{fake_uuid.hex}.png"
+    assert cli.generate_screenshot_name(image_path) == f"{fake_uuid.hex}.png"
 
 
 def test_generate_screenshot_name_for_gif(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24,7 +24,7 @@ def test_generate_screenshot_name_for_gif(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     gif_path = Path("/tmp/source/animation.gif")
-    assert cli.generate_screenshot_name(gif_path) == f"animated_{fake_uuid.hex}.gif"
+    assert cli.generate_screenshot_name(gif_path) == f"{fake_uuid.hex}.gif"
 
 
 def test_format_screenshots_path_for_git_skips_external_paths(tmp_path: Path) -> None:
@@ -147,7 +147,7 @@ def test_generate_screenshot_name_uppercase_jpg(monkeypatch: pytest.MonkeyPatch)
     image_path = Path("/tmp/source/Screenshot.JPG")
     result = cli.generate_screenshot_name(image_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.jpg"
+    assert result == f"{fake_uuid.hex}.jpg"
     assert result.endswith(".jpg")  # Verify lowercase
 
 
@@ -159,7 +159,7 @@ def test_generate_screenshot_name_uppercase_jpeg(monkeypatch: pytest.MonkeyPatch
     image_path = Path("/tmp/source/Photo.JPEG")
     result = cli.generate_screenshot_name(image_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.jpeg"
+    assert result == f"{fake_uuid.hex}.jpeg"
     assert result.endswith(".jpeg")
 
 
@@ -171,7 +171,7 @@ def test_generate_screenshot_name_mixed_case_png(monkeypatch: pytest.MonkeyPatch
     image_path = Path("/tmp/source/Image.PnG")
     result = cli.generate_screenshot_name(image_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.png"
+    assert result == f"{fake_uuid.hex}.png"
     assert result.endswith(".png")
 
 

--- a/tests/test_fetch_command.py
+++ b/tests/test_fetch_command.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -115,7 +116,7 @@ def test_fetch_with_default_settings(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
     assert str(dest_dir) in result.output
 
 
@@ -136,7 +137,7 @@ def test_fetch_with_custom_source(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
 
 
 def test_fetch_with_custom_destination(
@@ -210,7 +211,7 @@ def test_fetch_with_output_format_markdown(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
     assert "](" in result.output
 
 
@@ -240,7 +241,7 @@ def test_fetch_with_output_format_html(
 
     assert result.exit_code == 0
     assert '<img src="' in result.output
-    assert 'alt="screenshot_' in result.output
+    assert re.search(r'alt="[0-9a-f]{32}\.png"', result.output)
 
 
 def test_fetch_with_output_format_plain_text(
@@ -300,7 +301,7 @@ def test_fetch_with_output_style_markdown(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
     assert "](" in result.output
 
 
@@ -330,7 +331,7 @@ def test_fetch_with_output_style_html(
 
     assert result.exit_code == 0
     assert '<img src="' in result.output
-    assert 'alt="screenshot_' in result.output
+    assert re.search(r'alt="[0-9a-f]{32}\.png"', result.output)
 
 
 def test_fetch_with_output_style_text(
@@ -473,7 +474,7 @@ def test_fetch_with_direct_png_path(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
 
 
 def test_fetch_with_direct_jpg_path(
@@ -493,7 +494,7 @@ def test_fetch_with_direct_jpg_path(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.jpg\]\(", result.output)
 
 
 def test_fetch_with_direct_gif_path(
@@ -513,8 +514,7 @@ def test_fetch_with_direct_gif_path(
     )
 
     assert result.exit_code == 0
-    # GIF files should use 'animated_' prefix
-    assert "![animated_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.gif\]\(", result.output)
 
 
 def test_fetch_with_direct_jpeg_path(
@@ -534,7 +534,7 @@ def test_fetch_with_direct_jpeg_path(
     )
 
     assert result.exit_code == 0
-    assert "![screenshot_" in result.output
+    assert re.search(r"!\[[0-9a-f]{32}\.jpeg\]\(", result.output)
 
 
 def test_fetch_rejects_txt_file(
@@ -1056,7 +1056,7 @@ def test_fetch_uses_relative_paths_when_in_git_repo(
 
     assert result.exit_code == 0
     # Relative paths should start with / when in git repo
-    assert "](/images/screenshot_" in result.output or "](/images/animated_" in result.output
+    assert re.search(r"\]\(/images/[0-9a-f]{32}\.png\)", result.output)
 
 
 def test_fetch_uses_absolute_paths_when_not_in_git_repo(
@@ -1193,7 +1193,7 @@ def test_fetch_fetches_most_recent_screenshot(
 
     assert result.exit_code == 0
     # Should copy exactly one file (the most recent)
-    copied_files = list(dest_dir.glob("screenshot_*.png"))
+    copied_files = list(dest_dir.glob("*.png"))
     assert len(copied_files) == 1
 
 
@@ -1219,7 +1219,7 @@ def test_fetch_fetches_n_most_recent_when_count_n(
 
     assert result.exit_code == 0
     # Should copy exactly 3 files
-    copied_files = list(dest_dir.glob("screenshot_*.png"))
+    copied_files = list(dest_dir.glob("*.png"))
     assert len(copied_files) == 3
 
 
@@ -1288,7 +1288,7 @@ def test_fetch_stdout_contains_formatted_path(
 
     assert result.exit_code == 0
     assert result.output.strip()  # Should have output
-    assert "screenshot_" in result.output
+    assert re.search(r"[0-9a-f]{32}\.png", result.output)
 
 
 def test_fetch_markdown_format_in_output(
@@ -1316,7 +1316,7 @@ def test_fetch_markdown_format_in_output(
     )
 
     assert result.exit_code == 0
-    assert result.output.startswith("![screenshot_")
+    assert re.match(r"!\[[0-9a-f]{32}\.png\]\(", result.output)
     assert "](" in result.output
 
 
@@ -1346,7 +1346,7 @@ def test_fetch_html_format_in_output(
 
     assert result.exit_code == 0
     assert result.output.startswith("<img src=")
-    assert 'alt="screenshot_' in result.output
+    assert re.search(r'alt="[0-9a-f]{32}\.png"', result.output)
 
 
 def test_fetch_plain_text_format_in_output(
@@ -1686,7 +1686,7 @@ def test_fetch_convert_to_output_path_correct(
     assert result.exit_code == 0
     # Output should show .jpg extension, not .png
     assert ".jpg" in result.output
-    assert "screenshot_" in result.output
+    assert re.search(r"[0-9a-f]{32}\.jpg", result.output)
 
 
 def test_fetch_convert_to_no_conversion_when_same_format(

--- a/tests/test_path_sanitization.py
+++ b/tests/test_path_sanitization.py
@@ -7,6 +7,7 @@ to prevent information disclosure attacks.
 
 import ast
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -280,7 +281,7 @@ class TestFetchErrorMessages:
         assert str(source) not in result.output
         assert str(destination) not in result.output
         assert str(image_path) not in result.output
-        assert "<...>/screenshot_" in result.output
+        assert re.search(r"<\.\.\.>/[0-9a-f]{32}\.png", result.output)
         assert "secret.png" not in result.output
 
     def test_unreadable_source_directory_masks_real_path(
@@ -350,7 +351,7 @@ class TestFetchErrorMessages:
         assert result.exit_code == 1
         assert "Could not copy" in result.output
         assert "<...>/secret.png" in result.output
-        assert "<...>/screenshot_" in result.output
+        assert re.search(r"<\.\.\.>/[0-9a-f]{32}\.png", result.output)
         assert str(source) not in result.output
         assert str(destination) not in result.output
         assert str(image_path) not in result.output

--- a/tests/test_screenshot_operations.py
+++ b/tests/test_screenshot_operations.py
@@ -378,7 +378,7 @@ def test_copy_screenshots_generates_unique_uuid_filenames(
     result = cli.copy_screenshots((screenshot,), destination)
 
     assert len(result) == 1
-    assert result[0].name == f"screenshot_{fake_uuid.hex}.png"
+    assert result[0].name == f"{fake_uuid.hex}.png"
 
 
 def test_copy_screenshots_preserves_file_extensions(
@@ -440,7 +440,7 @@ def test_copy_screenshots_handles_multiple_files(
     for i, copied_path in enumerate(result):
         assert copied_path.exists()
         assert copied_path.parent == destination
-        assert copied_path.name == f"screenshot_{uuids[i].hex}.png"
+        assert copied_path.name == f"{uuids[i].hex}.png"
 
 
 def test_copy_screenshots_returns_tuple_of_path_objects(tmp_path: Path) -> None:
@@ -560,51 +560,51 @@ def test_copy_screenshots_respects_disabled_aggregate_cap(tmp_path: Path, capsys
 
 
 def test_generate_screenshot_name_with_png(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that generate_screenshot_name with .png generates 'screenshot_<uuid>.png'."""
+    """Test that generate_screenshot_name with .png generates '<uuid>.png'."""
     fake_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     screenshot_path = Path("/tmp/image.png")
     result = cli.generate_screenshot_name(screenshot_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.png"
+    assert result == f"{fake_uuid.hex}.png"
 
 
 def test_generate_screenshot_name_with_jpg(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that generate_screenshot_name with .jpg generates 'screenshot_<uuid>.jpg'."""
+    """Test that generate_screenshot_name with .jpg generates '<uuid>.jpg'."""
     fake_uuid = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     screenshot_path = Path("/tmp/photo.jpg")
     result = cli.generate_screenshot_name(screenshot_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.jpg"
+    assert result == f"{fake_uuid.hex}.jpg"
 
 
 def test_generate_screenshot_name_with_jpeg(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that generate_screenshot_name with .jpeg generates 'screenshot_<uuid>.jpeg'."""
+    """Test that generate_screenshot_name with .jpeg generates '<uuid>.jpeg'."""
     fake_uuid = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     screenshot_path = Path("/tmp/image.jpeg")
     result = cli.generate_screenshot_name(screenshot_path)
 
-    assert result == f"screenshot_{fake_uuid.hex}.jpeg"
+    assert result == f"{fake_uuid.hex}.jpeg"
 
 
 def test_generate_screenshot_name_with_gif(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that generate_screenshot_name with .gif generates 'animated_<uuid>.gif'."""
+    """Test that generate_screenshot_name with .gif generates '<uuid>.gif'."""
     fake_uuid = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
     screenshot_path = Path("/tmp/animation.gif")
     result = cli.generate_screenshot_name(screenshot_path)
 
-    assert result == f"animated_{fake_uuid.hex}.gif"
+    assert result == f"{fake_uuid.hex}.gif"
 
 
 def test_generate_screenshot_name_with_uppercase_gif(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that generate_screenshot_name with .GIF (uppercase) generates 'animated_<uuid>.gif'."""
+    """Test that generate_screenshot_name with .GIF (uppercase) generates '<uuid>.gif'."""
     fake_uuid = UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
     monkeypatch.setattr(cli.uuid, "uuid4", lambda: fake_uuid)
 
@@ -612,7 +612,7 @@ def test_generate_screenshot_name_with_uppercase_gif(monkeypatch: pytest.MonkeyP
     result = cli.generate_screenshot_name(screenshot_path)
 
     # Extension should be lowercased in output
-    assert result == f"animated_{fake_uuid.hex}.gif"
+    assert result == f"{fake_uuid.hex}.gif"
 
 
 def test_generate_screenshot_name_lowercases_extension(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -622,10 +622,10 @@ def test_generate_screenshot_name_lowercases_extension(monkeypatch: pytest.Monke
 
     # Test with various uppercase/mixed case extensions
     test_cases = [
-        (Path("/tmp/image.PNG"), f"screenshot_{fake_uuid.hex}.png"),
-        (Path("/tmp/photo.JPG"), f"screenshot_{fake_uuid.hex}.jpg"),
-        (Path("/tmp/image.JPEG"), f"screenshot_{fake_uuid.hex}.jpeg"),
-        (Path("/tmp/anim.GIF"), f"animated_{fake_uuid.hex}.gif"),
+        (Path("/tmp/image.PNG"), f"{fake_uuid.hex}.png"),
+        (Path("/tmp/photo.JPG"), f"{fake_uuid.hex}.jpg"),
+        (Path("/tmp/image.JPEG"), f"{fake_uuid.hex}.jpeg"),
+        (Path("/tmp/anim.GIF"), f"{fake_uuid.hex}.gif"),
     ]
 
     for input_path, expected_name in test_cases:

--- a/wslshot/cli.py
+++ b/wslshot/cli.py
@@ -1063,10 +1063,7 @@ def generate_screenshot_name(screenshot_path: Path) -> str:
     suffix = screenshot_path.suffix.lower()
     unique_fragment = uuid.uuid4().hex
 
-    if suffix == ".gif":
-        return f"animated_{unique_fragment}{suffix}"
-
-    return f"screenshot_{unique_fragment}{suffix}"
+    return f"{unique_fragment}{suffix}"
 
 
 def convert_image_format(source_path: Path, target_format: str) -> Path:


### PR DESCRIPTION
* `generate_screenshot_name()` now generates `{uuid}{ext}` for all formats.
* Update tests and `README.md`; add `scriv` fragment.

Co-authored-by: AI <ai@sderev.com>
