### PR TITLE
Internal improvements: config validation and magic constants

### DIFF
--- a/changelog.d/20260130_074809_sderev_internal_improvements.md
+++ b/changelog.d/20260130_074809_sderev_internal_improvements.md
@@ -1,0 +1,3 @@
+Fixed
+-----
+* Treated non-dict `config.json` as corruption (warning, backup, reset) instead of crashing.

--- a/wslshot/cli.py
+++ b/wslshot/cli.py
@@ -1594,6 +1594,12 @@ def validate_config(raw_config: dict[str, object]) -> dict[str, object]:
     Raises:
         ConfigurationError: If a value fails validation (except path existence)
     """
+    # Reject non-dict JSON (e.g., [], "", 123) early
+    if not isinstance(raw_config, dict):
+        raise ConfigurationError(
+            f"Invalid config format: expected object, got {type(raw_config).__name__}"
+        )
+
     validated: dict[str, object] = {}
 
     # Fields where non-existent paths are allowed (warn, don't fail)

--- a/wslshot/cli.py
+++ b/wslshot/cli.py
@@ -57,6 +57,10 @@ CONFIG_FILE_PERMISSIONS = 0o600
 CONFIG_DIR_PERMISSIONS = 0o700
 FILE_PERMISSION_MASK = 0o777
 
+# Config file location (relative parts only; Path.home() evaluated at runtime)
+CONFIG_DIR_RELATIVE = Path(".config") / "wslshot"
+CONFIG_FILE_NAME = "config.json"
+
 # Output formats
 OUTPUT_FORMAT_MARKDOWN = "markdown"
 OUTPUT_FORMAT_HTML = "html"
@@ -94,6 +98,9 @@ VALID_CONVERT_FORMATS = ("png", "jpg", "jpeg", "webp", "gif")
 
 # Supported image file extensions (lowercase)
 SUPPORTED_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif")
+
+# Image conversion quality (JPEG/WebP)
+IMAGE_SAVE_QUALITY = 95
 
 
 def normalize_optional_directory(value: object) -> str:
@@ -1421,11 +1428,11 @@ def convert_image_format(source_path: Path, target_format: str) -> Path:
 
             # Save with appropriate format
             if target_format == "jpg":
-                img.save(new_path, "JPEG", quality=95, optimize=True)
+                img.save(new_path, "JPEG", quality=IMAGE_SAVE_QUALITY, optimize=True)
             elif target_format == "png":
                 img.save(new_path, "PNG", optimize=True)
             elif target_format == "webp":
-                img.save(new_path, "WEBP", quality=95)
+                img.save(new_path, "WEBP", quality=IMAGE_SAVE_QUALITY)
             elif target_format == "gif":
                 img.save(new_path, "GIF", optimize=True)
 
@@ -1545,7 +1552,8 @@ def get_config_file_path(*, create_if_missing: bool = True) -> Path:
     """
     Get the configuration file path, optionally creating the file.
     """
-    config_file_path = Path.home() / ".config" / "wslshot" / "config.json"
+    config_dir = Path.home() / CONFIG_DIR_RELATIVE
+    config_file_path = config_dir / CONFIG_FILE_NAME
 
     if config_file_path.is_symlink():
         raise SecurityError("Config file is a symlink; refusing to use it.")


### PR DESCRIPTION
## What changed

* Treated non-dict JSON in `config.json` as corruption (warning, backup, reset) instead of crashing
* Extracted magic constants: `CONFIG_DIR_RELATIVE`, `CONFIG_FILE_NAME`, `IMAGE_SAVE_QUALITY`

## Why

* **Config validation**: Non-dict JSON previously crashed on `.keys()` in `validate_config()`. The new error path aligns with existing corruption handling and returns defaults with a warning.
* **Magic constants**: Naming inline literals makes intent clearer and reuse safer.

## How to test

```bash
gate
```

## Risk/compat notes

Low risk. User-facing behavior changes only for malformed configs (non-dict JSON), which now warn and reset defaults instead of crashing.

## Changelog fragment

Yes (user-facing bug fix).
