### PR TITLE
Add `--optimize` to `fetch` and validate flag interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Take a screenshot using the Windows Snipping tool (`win + shift + S`), then run 
 * Fetch the most recent screenshot or specify a number of recent screenshots to fetch.
 * Control automatic staging of screenshots when copied to a git repository.
 * Convert screenshots to `png`, `jpg`/`jpeg`, `webp`, or `gif` during copy (flag or default).
+* Optimize copied screenshots in place without changing filenames or extensions.
 * Set a default output style (Markdown, HTML, text) and specify a custom style per operation.
 
 ## Installation
@@ -156,6 +157,16 @@ wslshot --convert-to png
 
 This converts the screenshot(s) to the specified format. Supported formats: png, jpg, jpeg, webp, gif. If a default conversion is set in configuration, it runs when no flag is provided. Conversion happens after copying, and the converted file replaces the copied original. If auto-staging is enabled in a git repository, only the converted file is staged. Conversion is skipped only when the copied file already has the target extension; `.jpeg` files are rewritten to `.jpg`. Conversion applies both to the latest-screenshot workflow and when you pass a specific image path.
 
+**Optimize copied screenshots in place**:
+
+```bash
+wslshot --optimize
+```
+
+This optimizes copied screenshots after transfer and rewrites destination files in place. Source files are never modified. Optimization preserves each copied file's extension. If a default conversion format is configured, `--optimize` takes precedence for that run and skips conversion.
+
+`--optimize` conflicts with `--no-transfer` and `--convert-to`.
+
 **Allow symlinks (security risk)**:
 
 ```bash
@@ -167,7 +178,7 @@ WARNING: Only use with trusted paths. By default, `wslshot` rejects symlinks for
 **These are all the possible options**:
 
 ```bash
-wslshot [--source /custom/source] [--destination /custom/destination] [--count 3] [--output-style HTML] [--no-transfer] [--convert-to png] [--allow-symlinks]
+wslshot [--source /custom/source] [--destination /custom/destination] [--count 3] [--output-style HTML] [--no-transfer] [--convert-to png] [--optimize] [--allow-symlinks]
 ```
 
 ## Using a Specific Image Path

--- a/changelog.d/20260205_213305_sderev.md
+++ b/changelog.d/20260205_213305_sderev.md
@@ -1,0 +1,4 @@
+Changed
+-------
+* Added `fetch --optimize` to rewrite copied screenshots in place without changing filenames.
+* Added explicit conflicts for `--optimize` with `--no-transfer` and `--convert-to`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1015,15 +1015,15 @@ class TestGetValidatedDirectoryInput:
         monkeypatch.setattr(cli, "get_config_input", mock_get_config_input)
         monkeypatch.setattr(
             "click.echo",
-            lambda msg=None, **kwargs: error_messages.append(msg)
-            if msg and kwargs.get("err")
-            else None,
+            lambda msg=None, **kwargs: (
+                error_messages.append(msg) if msg and kwargs.get("err") else None
+            ),
         )
         monkeypatch.setattr(
             "click.secho",
-            lambda msg=None, **kwargs: error_messages.append(msg)
-            if msg and kwargs.get("err")
-            else None,
+            lambda msg=None, **kwargs: (
+                error_messages.append(msg) if msg and kwargs.get("err") else None
+            ),
         )
 
         result = cli.get_validated_directory_input("test_field", "Enter directory", {}, "")
@@ -1334,9 +1334,9 @@ class TestConfigPermissionEnforcement:
         monkeypatch.setattr(sys, "exit", mock_exit)
         monkeypatch.setattr(
             "click.echo",
-            lambda msg=None, **kwargs: error_messages.append(msg)
-            if msg and kwargs.get("err")
-            else None,
+            lambda msg=None, **kwargs: (
+                error_messages.append(msg) if msg and kwargs.get("err") else None
+            ),
         )
 
         with pytest.raises(SystemExit):
@@ -1367,9 +1367,9 @@ class TestConfigPermissionEnforcement:
         monkeypatch.setattr(sys, "exit", mock_exit)
         monkeypatch.setattr(
             "click.echo",
-            lambda msg=None, **kwargs: error_messages.append(msg)
-            if msg and kwargs.get("err")
-            else None,
+            lambda msg=None, **kwargs: (
+                error_messages.append(msg) if msg and kwargs.get("err") else None
+            ),
         )
 
         with pytest.raises(SystemExit):
@@ -1399,9 +1399,9 @@ class TestConfigPermissionEnforcement:
         monkeypatch.setattr(sys, "exit", mock_exit)
         monkeypatch.setattr(
             "click.echo",
-            lambda msg=None, **kwargs: error_messages.append(msg)
-            if msg and kwargs.get("err")
-            else None,
+            lambda msg=None, **kwargs: (
+                error_messages.append(msg) if msg and kwargs.get("err") else None
+            ),
         )
 
         with pytest.raises(SystemExit):

--- a/tests/test_no_transfer.py
+++ b/tests/test_no_transfer.py
@@ -274,6 +274,26 @@ def test_no_transfer_with_convert_to_errors(
     assert "--no-transfer" in result.output
 
 
+def test_no_transfer_with_optimize_errors(
+    runner: CliRunner,
+    fake_home: Path,
+    source_dir: Path,
+    config_file: Path,
+) -> None:
+    """Test --no-transfer + --optimize produces error."""
+    create_screenshot(source_dir, "screenshot.png")
+
+    result = runner.invoke(
+        cli.wslshot,
+        ["fetch", "--source", str(source_dir), "--no-transfer", "--optimize"],
+        env={"HOME": str(fake_home)},
+    )
+
+    assert result.exit_code == 2
+    assert "requires file transfer" in result.output
+    assert "--no-transfer" in result.output
+
+
 def test_no_transfer_with_destination_errors(
     runner: CliRunner,
     fake_home: Path,


### PR DESCRIPTION
What changed
* Added `fetch --optimize` to rewrite copied screenshots in place without changing extension.
* Added conflict validation via `click.BadOptionUsage` for `--optimize` with `--no-transfer` and with `--convert-to`.
* Ensured `--optimize` takes precedence over configured `default_convert_to` for that run.
* Added unit tests for optimize success path and conflict cases.
* Updated `README.md` for usage and conflicts.
* Added changelog fragment `changelog.d/20260205_213305_sderev.md`.

Why
* Allow explicit, opt-in image optimization without silent format conversion.
* Keep CLI semantics unambiguous for write/no-write flows.

How to test
* Automated:
* `uv run pytest tests/test_fetch_command.py tests/test_no_transfer.py tests/test_image_conversion.py`
* Manual:
* Run `wslshot fetch --source <dir> --destination <dir> --optimize` with a `.png` screenshot and confirm output file stays `.png`.
* Run `wslshot fetch --source <dir> --no-transfer --optimize` and confirm CLI exits with `BadOptionUsage` message.
* Run `wslshot fetch --source <dir> --destination <dir> --convert-to jpg --optimize` and confirm CLI exits with conflict message.
* Configure default conversion (`wslshot configure --convert-to webp`), then run `wslshot fetch --optimize` and confirm copied file keeps original extension.

Risk/comp notes
* `gate` currently reports unrelated formatting issue in `tests/test_config.py` (pre-existing).
* Optimization path uses Pillow rewrite in place; no source-file writes.

Changelog fragment: yes (user-facing CLI feature)
