### PR TITLE
Allow `config.json` symlink targets and tame stale image warnings

### DIFF
--- a/changelog.d/20260206_030313_sderev_config_symlink_invalid_warnings.md
+++ b/changelog.d/20260206_030313_sderev_config_symlink_invalid_warnings.md
@@ -1,0 +1,4 @@
+Fixed
+-----
+* Allowed `~/.config/wslshot/config.json` to be a symlink and kept writes on its target file.
+* Changed screenshot discovery to validate newest candidates first, so stale invalid files no longer spam warnings on routine runs.


### PR DESCRIPTION
* Support symlinked `~/.config/wslshot/config.json` by resolving and writing the target file.
* Validate screenshot candidates from newest to oldest and stop once `--count` valid files are found.
* Add regression tests for symlinked config handling and stale invalid-file warnings.
* Add a `scriv` fragment for the user-visible behavior change.
* Verify with `gate` and direct `uv run --group dev -- wslshot` runs.

Co-authored-by: AI <ai@sderev.com>
