### PR TITLE
Auto-populate GitHub release notes from `CHANGELOG.md`

### DIFF
--- a/.ci/changelog-notes
+++ b/.ci/changelog-notes
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Extract release notes for a version from CHANGELOG.md.
+
+Reads the matching ``## <version>`` section, converts RST-style underlined
+category headers to Markdown ``###`` headers, and prints the result.
+
+Usage::
+
+    .ci/changelog-notes <version> [changelog-path]
+    .ci/changelog-notes 0.1.1
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def extract_notes(changelog: str, version: str) -> str | None:
+    """Return the release-notes section for *version*, or ``None``."""
+    header = re.compile(rf"^## {re.escape(version)}\b[^\n]*$", re.MULTILINE)
+    match = header.search(changelog)
+    if not match:
+        return None
+
+    start = match.end() + 1  # skip past header line's newline
+
+    # The section ends at the next version header or ``<a id=`` anchor.
+    boundary = re.compile(r"^(?:## |<a id=)", re.MULTILINE)
+    end_match = boundary.search(changelog, start)
+    raw = changelog[start : end_match.start()] if end_match else changelog[start:]
+
+    # Convert RST underlined headers (``Category\n-----``) → ``### Category``
+    notes = re.sub(r"^(.+)\n-{3,}$", r"### \1", raw, flags=re.MULTILINE)
+    return notes.strip()
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: changelog-notes <version> [changelog]", file=sys.stderr)
+        return 2
+
+    version = sys.argv[1]
+    path = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("CHANGELOG.md")
+
+    if not path.is_file():
+        print(f"error: {path} not found", file=sys.stderr)
+        return 1
+
+    notes = extract_notes(path.read_text(), version)
+    if notes is None:
+        print(f"error: version {version} not found in {path}", file=sys.stderr)
+        return 1
+
+    print(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,24 @@ permissions:
   contents: read
 
 jobs:
+  release-notes:
+    name: Populate release notes from CHANGELOG.md
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update release body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#v}"
+          python3 .ci/changelog-notes "$version" > /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md
+
   build:
     name: Build distribution packages
     runs-on: ubuntu-latest

--- a/uv.lock
+++ b/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "wslshot"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What changed
* Add `.ci/changelog-notes` Python script that extracts a version's section from `CHANGELOG.md` and converts RST underlined category headers to Markdown `###`.
* Add `release-notes` job to `release.yml` that runs on `release: published`, reads the changelog, and updates the release body via `gh release edit`.
* Sync `uv.lock` with the 0.1.1 version already in `pyproject.toml`.

## Why
GitHub releases were empty — clicking on a release showed no description. The changelog content should appear automatically.

## How to test
1. Verify the script works locally: `.ci/changelog-notes 0.1.1` and `.ci/changelog-notes 0.1.0`.
2. Check error handling: `.ci/changelog-notes 9.9.9` exits with code 1.
3. After merge, create a test pre-release (`gh release create test-0.0.0 --prerelease --target main --title test`) and verify the `release-notes` job runs and populates the body. Then delete it.

## Risk/compat notes
* The `release-notes` job needs `contents: write`; scoped per-job, does not widen permissions for `build` or `publish`.
* If a version is missing from `CHANGELOG.md`, the job fails visibly without affecting PyPI publish (independent job).

## Changelog fragment
No — internal CI tooling, not user-facing.